### PR TITLE
HasValue also needs TemplateId check

### DIFF
--- a/src/Our.Umbraco.FriendlySitemap/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.FriendlySitemap/Extensions/PublishedContentExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.Models.PublishedContent;
 
 namespace Our.Umbraco.FriendlySitemap.Extensions
 {
@@ -6,7 +6,7 @@ namespace Our.Umbraco.FriendlySitemap.Extensions
     {
         public static bool HasTemplate(this IPublishedContent content)
         {
-            return content.TemplateId.HasValue == true;
+            return content.TemplateId.HasValue == true && content.TemplateId > 0;
         }
     }
 }


### PR DESCRIPTION
Any node without a template has a `TemplateId` of `0`, which means the `HasValue` check always returns `True`. I have added a check to see if the `TemplateId` is also greater than `0` for this scenario.