### PR TITLE
Remove trailing slash from sitemap namespace

### DIFF
--- a/src/Our.Umbraco.FriendlySitemap/Builders/SitemapBuilder.cs
+++ b/src/Our.Umbraco.FriendlySitemap/Builders/SitemapBuilder.cs
@@ -8,7 +8,7 @@ namespace Our.Umbraco.FriendlySitemap.Builders
 {
     public class SitemapBuilder : ISitemapBuilder
     {
-        private readonly XNamespace _xmlns = XNamespace.Get("https://www.sitemaps.org/schemas/sitemap/0.9/");
+        private readonly XNamespace _xmlns = XNamespace.Get("https://www.sitemaps.org/schemas/sitemap/0.9");
 
         public XDocument BuildSitemap(IPublishedContent startNode)
         {


### PR DESCRIPTION
I've removed the trailing slash from xml Namespace, because Google Search Console reports it as an invalid link with it.

I found this out when I copied the builder code to control how my sitemap processed my site.

This is from my original deployment:
![image](https://user-images.githubusercontent.com/13313745/94861973-40fa0300-0430-11eb-888e-ed143494b657.png)

This is from my custom deployment with the / removed
![image](https://user-images.githubusercontent.com/13313745/94862042-5707c380-0430-11eb-8df1-cf09414a6a18.png)

Unfortunately I didn't save a copy of the full error details about the namespace.