### PR TITLE
use correct xmlns namespace

### DIFF
--- a/src/Our.Umbraco.FriendlySitemap/Builders/SitemapBuilder.cs
+++ b/src/Our.Umbraco.FriendlySitemap/Builders/SitemapBuilder.cs
@@ -8,7 +8,7 @@ namespace Our.Umbraco.FriendlySitemap.Builders
 {
     public class SitemapBuilder : ISitemapBuilder
     {
-        private readonly XNamespace _xmlns = XNamespace.Get("https://www.sitemaps.org/schemas/sitemap/0.9");
+        private readonly XNamespace _xmlns = XNamespace.Get("http://www.sitemaps.org/schemas/sitemap/0.9");
 
         public XDocument BuildSitemap(IPublishedContent startNode)
         {


### PR DESCRIPTION
Fix for issue #14

The xmlns URI is really just an opaque ID, called a "namespace name".

As such, its "name" is http://www.sitemaps.org/schemas/sitemap/0.9 and not https://www.sitemaps.org/schemas/sitemap/0.9