### PR TITLE
do not want to include nodes that does not start with http

### DIFF
--- a/src/Our.Umbraco.FriendlySitemap/Builders/SitemapBuilder.cs
+++ b/src/Our.Umbraco.FriendlySitemap/Builders/SitemapBuilder.cs
@@ -21,7 +21,9 @@ namespace Our.Umbraco.FriendlySitemap.Builders
 
             foreach (var node in nodes)
             {
-                urlsetElement.Add(BuildNode(node));
+                var buildNode = BuildNode(node);
+                if(buildNode == null) continue;
+                urlsetElement.Add(buildNode);
             }
 
             var doc = new XDocument(urlsetElement);
@@ -31,9 +33,15 @@ namespace Our.Umbraco.FriendlySitemap.Builders
 
         public XElement BuildNode(IPublishedContent node)
         {
+            var url = node.Url(mode: UrlMode.Absolute);
+            if (url.StartsWith("http") == false)
+            {
+                // this is an invalid url, possibly because a domain is configured without host (eg /en)
+                return null;
+            }
             var urlElement = new XElement(_xmlns + "url", new[]
             {
-                new XElement(_xmlns + "loc", node.Url(mode: UrlMode.Absolute)),
+                new XElement(_xmlns + "loc", url),
                 new XElement(_xmlns + "lastmod", node.UpdateDate.ToString("yyyy-MM-dd"))
             });
 

--- a/src/Our.Umbraco.FriendlySitemap/Builders/SitemapBuilder.cs
+++ b/src/Our.Umbraco.FriendlySitemap/Builders/SitemapBuilder.cs
@@ -8,7 +8,7 @@ namespace Our.Umbraco.FriendlySitemap.Builders
 {
     public class SitemapBuilder : ISitemapBuilder
     {
-        private readonly XNamespace _xmlns = XNamespace.Get("https://www.sitemaps.org/schemas/sitemap/0.9/");
+        private readonly XNamespace _xmlns = XNamespace.Get("https://www.sitemaps.org/schemas/sitemap/0.9");
 
         public XDocument BuildSitemap(IPublishedContent startNode)
         {


### PR DESCRIPTION
If you configure a domain with /en (instead of a hostname) which is allowed in Umbraco, than that url will be added to the sitemap

This PR adds a safe guard to prevent this from happening.  

I am wondering if this is the best approach though...  :-)